### PR TITLE
Set legacy swift version

### DIFF
--- a/src/add-swift-support.js
+++ b/src/add-swift-support.js
@@ -131,6 +131,12 @@ module.exports = function(context) {
               xcodeProject.updateBuildProperty('LD_RUNPATH_SEARCH_PATHS','"@executable_path/Frameworks"', buildConfig.name);
               console.log('Update IOS build setting LD_RUNPATH_SEARCH_PATHS to: @executable_path/Frameworks', 'for build configuration', buildConfig.name);
             }
+
+            if(typeof xcodeProject.getBuildProperty('SWIFT_VERSION', buildConfig.name) === 'undefined') {
+              xcodeProject.updateBuildProperty('SWIFT_VERSION','3.0', buildConfig.name);
+              console.log('Update SWIFT version to', 3.0, buildConfig.name);
+            }
+
           }
         }
 


### PR DESCRIPTION
I had the issue that i could not build via CLI because the swift version was not set in build settings. close #15 .

I resolved this for by setting the project to swift version 3 for Xcode 8. Do you think this could be relevant for this plugin or is there a better approach to this? 