### PR TITLE
enabled debugging swift in Debug configuration

### DIFF
--- a/src/add-swift-support.js
+++ b/src/add-swift-support.js
@@ -146,6 +146,13 @@ module.exports = function (context) {
                 console.log('Update SWIFT version to 3.0', buildConfig.name);
               }
             }
+
+            if (buildConfig.name === 'Debug') {
+              if (xcodeProject.getBuildProperty('SWIFT_OPTIMIZATION_LEVEL', buildConfig.name) !== '"-Onone"') {
+                xcodeProject.updateBuildProperty('SWIFT_OPTIMIZATION_LEVEL', '"-Onone"', buildConfig.name);
+                console.log('Update IOS build setting SWIFT_OPTIMIZATION_LEVEL to: -Onone', 'for build configuration', buildConfig.name);
+              }
+            }
           }
         }
 


### PR DESCRIPTION
Hi, thank you for great plugin!

I used to switch **build settings>swift compiler code generation>optimization level** manually to **none** each time I wanted to debug swift. Finally added this switch to the plugin.

With this change, when in debug configuration, swift code is debuggable directly in cordova project.

Please merge.