### PR TITLE
Set swift version in config.xml

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -141,6 +141,10 @@ export default (context) => {
               if (config.getPreference('UseLegacySwiftLanguageVersion', 'ios')) {
                 xcodeProject.updateBuildProperty('SWIFT_VERSION', '2.3', buildConfig.name);
                 console.log('Use legacy Swift language version', buildConfig.name);
+              } else if (config.getPreference('UseSwiftLanguageVersion', 'ios')) {
+                const swiftVersion = config.getPreference('UseSwiftLanguageVersion', 'ios');
+                xcodeProject.updateBuildProperty('SWIFT_VERSION', swiftVersion, buildConfig.name);
+                console.log('Use Swift language version', swiftVersion);
               } else {
                 xcodeProject.updateBuildProperty('SWIFT_VERSION', '3.0', buildConfig.name);
                 console.log('Update SWIFT version to 3.0', buildConfig.name);


### PR DESCRIPTION
I am using XCode 9 beta which only supports Swift 3.2 and 4. This pull requests adds the possibility to set the Swift version in config.xml.

What do you think? 