### PR TITLE
Fix for cordova projects located in paths with spaces

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -197,10 +197,13 @@ const getPlatformVersionsFromFileSystem = (context, projectRoot) => {
   const platformsOnFs = cordovaUtil.listPlatforms(projectRoot);
   const platformVersions = platformsOnFs.map((platform) => {
     const script = path.join(projectRoot, 'platforms', platform, 'cordova', 'version');
-    return Q.ninvoke(childProcess, 'exec', script, {}).then((result) => {
+    return Q.ninvoke(childProcess, 'exec', '"' + script + '"', {}).then((result) => {
       const version = result[0];
       const versionCleaned = version.replace(/\r?\n|\r/g, '');
       return {platform: platform, version: versionCleaned};
+    }, (error) => {
+      console.log(error);
+      process.exit(1);
     });
   });
 


### PR DESCRIPTION
We had an issue very similar to #47.

The shell execution of the cordova version script silently failed because the full path where our cordova project was located contained whitespaces (and other conflicting characters like '(' and '(' ). As a result, the promise returned by getPlatformVersionsFromFileSystem rejected and no changes to the xcode project were applied by this plugin. Wrapping the script command in quotation commands solved the problem for us.