### PR TITLE
Fix pod install warning

### DIFF
--- a/src/add-swift-support.js
+++ b/src/add-swift-support.js
@@ -131,9 +131,17 @@ module.exports = context => {
               console.log('Update IOS build setting ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES to: YES', 'for build configuration', buildConfig.name);
             }
 
-            if (xcodeProject.getBuildProperty('LD_RUNPATH_SEARCH_PATHS', buildConfig.name) !== '"@executable_path/Frameworks"') {
-              xcodeProject.updateBuildProperty('LD_RUNPATH_SEARCH_PATHS', '"@executable_path/Frameworks"', buildConfig.name);
-              console.log('Update IOS build setting LD_RUNPATH_SEARCH_PATHS to: @executable_path/Frameworks', 'for build configuration', buildConfig.name);
+            let ldRunpathSearchPaths = xcodeProject.getBuildProperty('LD_RUNPATH_SEARCH_PATHS', buildConfig.name);
+            if (ldRunpathSearchPaths === undefined || ldRunpathSearchPaths.indexOf('"@executable_path/Frameworks"') === -1) {
+              if (ldRunpathSearchPaths === undefined) {
+                ldRunpathSearchPaths = ['"$(inherited)"', '"@executable_path/Frameworks"'];
+              } else if (typeof ldRunpathSearchPaths === 'string') {
+                ldRunpathSearchPaths = [ldRunpathSearchPaths, '"@executable_path/Frameworks"'];
+              } else if (Array.isArray(ldRunpathSearchPaths)) {
+                ldRunpathSearchPaths.push('"@executable_path/Frameworks"');
+              }
+              xcodeProject.updateBuildProperty('LD_RUNPATH_SEARCH_PATHS', ldRunpathSearchPaths, buildConfig.name);
+              console.log('Update IOS build setting LD_RUNPATH_SEARCH_PATHS to:', ldRunpathSearchPaths, 'for build configuration', buildConfig.name);
             }
 
             if (typeof xcodeProject.getBuildProperty('SWIFT_VERSION', buildConfig.name) === 'undefined') {


### PR DESCRIPTION
When I install this plugin and then install some libraries via CocoaPods, a warning will pop up:
```
[!] The `HelloCordova [Debug]` target overrides the `LD_RUNPATH_SEARCH_PATHS` build setting defined in `Pods/Target Support Files/Pods-HelloCordova/Pods-HelloCordova.debug.xcconfig'. This can lead to problems with the CocoaPods installation

[!] The `HelloCordova [Release]` target overrides the `LD_RUNPATH_SEARCH_PATHS` build setting defined in `Pods/Target Support Files/Pods-HelloCordova/Pods-HelloCordova.release.xcconfig'. This can lead to problems with the CocoaPods installation
```
This PR will fix the warning.