### PR TITLE
Update package.json with correct license

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "cordova-ios",
     "cordova:plugin"
   ],
-  "license": "Apache-2.0",
+  "license": "MIT",
   "dependencies": {
     "glob": "^7.1.3",
     "semver": "^6.0.0",


### PR DESCRIPTION
As already mentioned in https://github.com/akofman/cordova-plugin-add-swift-support/issues/68, the license in the package.json (Apache 2.0)  does not match the license-text (MIT).