### PR TITLE
add SWIFT_COMPILATION_MODE = wholemodule

### DIFF
--- a/src/add-swift-support.js
+++ b/src/add-swift-support.js
@@ -131,6 +131,11 @@ module.exports = context => {
               console.log('Update IOS build setting ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES to: YES', 'for build configuration', buildConfig.name);
             }
 
+            if (xcodeProject.getBuildProperty('SWIFT_COMPILATION_MODE', buildConfig.name) !== 'wholemodule') {
+              xcodeProject.updateBuildProperty('SWIFT_COMPILATION_MODE', 'wholemodule', buildConfig.name);
+              console.log('Update IOS build setting SWIFT_COMPILATION_MODE to: wholemodule', 'for build configuration', buildConfig.name);
+            }
+
             if (xcodeProject.getBuildProperty('LD_RUNPATH_SEARCH_PATHS', buildConfig.name) !== '"@executable_path/Frameworks"') {
               xcodeProject.updateBuildProperty('LD_RUNPATH_SEARCH_PATHS', '"@executable_path/Frameworks"', buildConfig.name);
               console.log('Update IOS build setting LD_RUNPATH_SEARCH_PATHS to: @executable_path/Frameworks', 'for build configuration', buildConfig.name);


### PR DESCRIPTION
This fixes a bug where TestFlight/App Store apps were crashing on iOS 12 when compiled with Xcode 15+.

To reproduce:
- have a Cordova project that has **any** Swift file in it (and make sure the Swift file properly belongs to project target)
- Deployment Target = iOS 12.0
- Xcode version >= 15 (I was using 15.1)

Then to reproduce:
- in Xcode go to Product -> Archive and then Distribute to TestFlight + App Store. Witness crash on launch once app reaches your device

OR, to skip waiting on TestFlight/App Store:

- In Xcode go to Product -> Profile 
- Once "Profile" is done and has installed the app on your device, either launch the app from your iPad/iPhone, or choose "Activity Monitor" when Instruments launches after the "Profile" step finishes, and hit the little red record button top left
- App should crash on launch

For the aid of future users Googling, this was the only error I could glean, which I saw in the system console. There are no stack traces because the app does not successfully launch on iOS 12:

```
Attempt to add an app with insufficient id, info {
    BKSApplicationStateAppIsFrontmost = 1;
    BKSApplicationStateExtensionKey = 0;
    SBApplicationStateDisplayIDKey = "com.dinnerwire.SmartKDS";
    SBApplicationStateKey = 8;
    SBApplicationStateProcessIDKey = 472;
    SBApplicationStateRunningReasonsKey =     (
                {
            SBApplicationStateRunningReasonAssertionIdentifierKey = UIApplicationLaunch;
            SBApplicationStateRunningReasonAssertionReasonKey = 10000;
        }
    );
    SBMostElevatedStateForProcessID = 8;
}
```

And:

```
SyscallError: setpriority(PRIO_DARWIN_ROLE, 787, 3): No such process
```

https://forum.ionicframework.com/t/ios-12-app-crashes-on-opening-and-closes-quickly-libswift-concurrency-dylib/230206